### PR TITLE
 Extend the task model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 ve
 .project
 .pydevproject
+sandbox

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ $(PY_SENTINAL):
 	touch $@
 
 flake8: $(PY_SENTINAL)
-	$(FLAKE8) $(PY_DIRS) --exclude ve,virtualenv.py
+	$(FLAKE8) $(PY_DIRS) --exclude ve,virtualenv.py,sandbox

--- a/README.md
+++ b/README.md
@@ -74,3 +74,5 @@ checked out repos are up to date:
       --base=/home/anders/code/python \
       --uworld=1
 
+## Common Tasks
+

--- a/README.md
+++ b/README.md
@@ -73,6 +73,3 @@ checked out repos are up to date:
     $ ./upgrayedd.py --repos=repos.txt \
       --base=/home/anders/code/python \
       --uworld=1
-
-## Common Tasks
-

--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,134 @@
+import argparse
+
+from tasks import (
+    TaskRunner, CloneTask, CheckoutTask, NewBranchTask, MakeTask,
+    CommitAndPushTask, StatusTask, PublishTask, RequirementsUpdateTask,
+    MergeMatchingPullRequestTask)
+
+
+def main(args):
+    base = args.base
+    repos = args.repos
+
+    f = open(repos)
+
+    if args.clone:
+        print('Clone')
+        runner = TaskRunner()
+        for line in f:
+            r = line.strip()
+            runner.run(CloneTask(base, r))
+        runner.print_report()
+
+    if args.status:
+        print('Status')
+        runner = TaskRunner()
+        for line in f:
+            r = line.strip()
+            runner.run(StatusTask(base, r))
+        runner.print_report()
+
+    if args.checkout:
+        print('Checkout a branch')
+        runner = TaskRunner()
+        for line in f:
+            r = line.strip()
+            runner.run(CheckoutTask(base, r, args.checkout))
+        runner.print_report()
+
+    if args.new_branch:
+        print('Create New Branch')
+        runner = TaskRunner()
+        for line in f:
+            r = line.strip()
+            runner.run(NewBranchTask(base, r, args.new_branch))
+        runner.print_report()
+
+    if args.make:
+        print('Make All')
+        runner = TaskRunner()
+        for line in f:
+            r = line.strip()
+            runner.run(MakeTask(base, r))
+        runner.print_report()
+
+    if args.commit:
+        print('Commit And Push')
+        runner = TaskRunner()
+        for line in f:
+            r = line.strip()
+            runner.run(CommitAndPushTask(base, r, args.commit, args.message))
+        runner.print_report()
+
+    if args.publish:
+        print('Publish')
+        runner = TaskRunner()
+        for line in f:
+            r = line.strip()
+            runner.run(PublishTask(base, r))
+        runner.print_report()
+
+    if args.match and args.replace:
+        print('Requirements Update')
+        runner = TaskRunner()
+        for line in f:
+            r = line.strip()
+            runner.run(
+                RequirementsUpdateTask(base, r, args.match, args.replace))
+        runner.print_report()
+
+    if args.match and args.owner:
+        print('Merge pull request')
+        runner = TaskRunner()
+        for line in f:
+            r = line.strip()
+            runner.run(
+                MergeMatchingPullRequestTask(
+                    base, r, args.owner, args.match, args.api_token))
+        runner.print_report()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='upgrade libraries')
+    parser.add_argument(
+        '--base', help='base directory')
+    parser.add_argument(
+        '--repos', help='path to repos.txt file', default='./repos.txt')
+
+    parser.add_argument(
+        '--clone', action='store_true', help='full repo clone')
+
+    parser.add_argument(
+        '--checkout', help='checkout this branch')
+
+    parser.add_argument(
+        '--new_branch', help='git branch name')
+
+    parser.add_argument(
+        '--make', action='store_true', help='make all targets')
+
+    parser.add_argument(
+        '--commit', help='git branch name to commit to')
+    parser.add_argument(
+        '--message', help='commit message')
+
+    parser.add_argument(
+        '--status', action='store_true', help='status')
+
+    parser.add_argument(
+        '--publish', action='store_true', help='publish')
+
+    parser.add_argument(
+        '--match', help='pattern to match')
+
+    parser.add_argument(
+        '--replace', help='pattern to replace')
+
+    parser.add_argument(
+        '--owner', help='repo owner')
+
+    parser.add_argument(
+        '--api_token', help='Github oauth token')
+
+    args = parser.parse_args()
+    main(args)

--- a/steps.py
+++ b/steps.py
@@ -1,0 +1,105 @@
+import subprocess
+
+import requests
+
+
+class Step(object):
+    def __init__(self, cmd, label, upgrader, skip_fail='fail'):
+        self.upgrader = upgrader
+        self.cmd = cmd
+        self.label = label
+        self.skip_fail = skip_fail
+
+    def run(self):
+        if self.upgrader.status == 'failed':
+            return
+        if self.upgrader.status == 'skipped':
+            return
+        ret = subprocess.call(self.cmd)
+        if ret:
+            if self.skip_fail == 'fail':
+                self.upgrader.fail(self.label)
+            else:
+                self.upgrader.skip()
+
+
+class CommitStatusStep(object):
+
+    def __init__(self, label, upgrader, skip_fail='fail'):
+        self.upgrader = upgrader
+        self.label = label
+        self.skip_fail = skip_fail
+
+    def run(self):
+        if self.upgrader.status == 'failed':
+            return
+        if self.upgrader.status == 'skipped':
+            return
+
+        url = '{}/{}/{}/commits/{}/status'.format(
+            self.upgrader.git_base, self.upgrader.owner,
+            self.upgrader.repo, self.upgrader.pattern)
+
+        response = requests.get(url, headers=self.upgrader.headers)
+        if (response.status_code != 200 or
+                response.json()['state'] != 'success'):
+            if self.skip_fail == 'fail':
+                self.upgrader.fail(self.label)
+            else:
+                self.upgrader.skip()
+
+
+class PullRequestStep(object):
+
+    def __init__(self, label, upgrader, skip_fail='fail'):
+        self.upgrader = upgrader
+        self.label = label
+        self.skip_fail = skip_fail
+
+    def run(self):
+        if self.upgrader.status == 'failed':
+            return
+        if self.upgrader.status == 'skipped':
+            return
+
+        url = '{}/{}/{}/pulls'.format(
+            self.upgrader.git_base, self.upgrader.owner, self.upgrader.repo)
+
+        response = requests.get(url, headers=self.upgrader.headers)
+        if response.status_code == 200:
+            for pr in response.json():
+                if self.upgrader.pattern == pr['head']['ref']:
+                    self.upgrader.number = pr['number']
+                    return
+
+        # no matching pull request
+        if self.skip_fail == 'fail':
+            self.upgrader.fail(self.label)
+        else:
+            self.upgrader.skip()
+
+
+class MergeStep(object):
+
+    def __init__(self, label, upgrader, skip_fail='fail'):
+        self.upgrader = upgrader
+        self.label = label
+        self.skip_fail = skip_fail
+
+    def run(self):
+        if self.upgrader.status == 'failed':
+            return
+        if self.upgrader.status == 'skipped':
+            return
+
+        url = '{}/{}/{}/pulls/{}/merge'.format(
+            self.upgrader.git_base, self.upgrader.owner,
+            self.upgrader.repo, self.upgrader.number)
+
+        response = requests.put(url, headers=self.upgrader.headers)
+        if response.status_code != 200:
+            # no matching pull request
+            if self.skip_fail == 'fail':
+                self.upgrader.fail(self.label)
+            else:
+                self.upgrader.skip()

--- a/steps.py
+++ b/steps.py
@@ -98,7 +98,6 @@ class MergeStep(object):
 
         response = requests.put(url, headers=self.upgrader.headers)
         if response.status_code != 200:
-            # no matching pull request
             if self.skip_fail == 'fail':
                 self.upgrader.fail(self.label)
             else:

--- a/tasks.py
+++ b/tasks.py
@@ -250,7 +250,7 @@ class MergeMatchingPullRequestTask(Task):
         steps = [
             CommitStatusStep('commit status', self),
             PullRequestStep('pull request info', self),
-            MergeStep('merge the pr', self),
+            MergeStep('merge the pr', self)
         ]
 
         for s in steps:

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,339 @@
+import os
+import subprocess
+
+import requests
+
+
+class Step(object):
+    def __init__(self, cmd, label, upgrader, skip_fail='fail'):
+        self.upgrader = upgrader
+        self.cmd = cmd
+        self.label = label
+        self.skip_fail = skip_fail
+
+    def run(self):
+        if self.upgrader.status == 'failed':
+            return
+        if self.upgrader.status == 'skipped':
+            return
+        ret = subprocess.call(self.cmd)
+        if ret:
+            if self.skip_fail == 'fail':
+                self.upgrader.fail(self.label)
+            else:
+                self.upgrader.skip()
+
+
+class Task(object):
+
+    def full_repo_path(self):
+        return os.path.join(self.base, self.repo)
+
+    def requirements_path(self):
+        return os.path.join(self.base, self.repo, 'requirements.txt')
+
+    def package_json_path(self):
+        return os.path.join(self.base, self.repo, "package.json")
+
+    def replace_pattern(self):
+        return 's/%s/%s/' % (self.match, self.replace)
+
+    def fail(self, msg):
+        self.status = 'failed'
+        self.log = msg
+
+    def skip(self):
+        self.status = 'skipped'
+
+
+class CloneTask(Task):
+    def __init__(self, base, repo):
+        self.base = base
+        self.repo = repo
+        self.status = 'running'
+        self.log = ''
+
+    def make(self):
+        print('====== %s =======' % self.repo)
+        os.chdir(self.base)
+
+        gitref = 'git@github.com:ccnmtl/{}.git'.format(self.repo)
+
+        steps = [Step(
+            ['git', 'clone', gitref],
+            'git clone {}'.format(gitref),
+            self)]
+
+        for s in steps:
+            s.run()
+        if self.status != 'failed' and self.status != 'skipped':
+            self.status = 'success'
+        return
+
+
+class CheckoutTask(Task):
+    def __init__(self, base, repo, branch):
+        self.base = base
+        self.repo = repo
+        self.branch = branch
+        self.status = 'running'
+        self.log = ''
+
+    def make(self):
+        print('====== %s =======' % self.repo)
+        os.chdir(self.full_repo_path())
+
+        steps = [
+            Step(['git', 'checkout', self.branch],
+                 'git checkout {}'.format(self.branch),
+                 self),
+            Step(["git", "reset", "--hard"], "git reset --hard",
+                 self),
+            Step(['git', 'pull'], 'git pull', self),
+        ]
+
+        for s in steps:
+            s.run()
+        if self.status != 'failed' and self.status != 'skipped':
+            self.status = 'success'
+        return
+
+
+class NewBranchTask(Task):
+    def __init__(self, base, repo, branch):
+        self.base = base
+        self.repo = repo
+        self.branch = branch
+        self.status = 'running'
+        self.log = ''
+
+    def make(self):
+        print('====== %s =======' % self.repo)
+        os.chdir(self.full_repo_path())
+
+        steps = [
+            Step(['git', 'checkout', 'master'],
+                 'git checkout master', self),
+            Step(['git', 'reset', '--hard'],
+                 'git reset --hard', self),
+            Step(['git', 'pull'],
+                 'git pull', self),
+            Step(['git', 'checkout', '-b', self.branch],
+                 'create new branch', self),
+            ]
+
+        for s in steps:
+            s.run()
+        if self.status != 'failed' and self.status != 'skipped':
+            self.status = 'success'
+        return
+
+
+class MakeTask(Task):
+    def __init__(self, base, repo):
+        self.base = base
+        self.repo = repo
+        self.status = 'running'
+        self.log = ''
+
+    def make(self):
+        print('====== %s =======' % self.repo)
+        os.chdir(self.full_repo_path())
+        steps = [Step(['make'], 'make', self)]
+
+        for s in steps:
+            s.run()
+        if self.status != 'failed' and self.status != 'skipped':
+            self.status = 'success'
+        return
+
+
+class StatusTask(Task):
+    def __init__(self, base, repo):
+        self.base = base
+        self.repo = repo
+        self.status = 'running'
+        self.log = ''
+
+    def make(self):
+        print('====== %s =======' % self.repo)
+        os.chdir(self.full_repo_path())
+
+        steps = [
+            Step(['git', 'status'],
+                 'git status', self),
+            ]
+
+        for s in steps:
+            s.run()
+        if self.status != 'failed' and self.status != 'skipped':
+            self.status = 'success'
+        return
+
+
+class CommitAndPushTask(Task):
+    def __init__(self, base, repo, branch, message):
+        self.base = base
+        self.repo = repo
+        self.branch = branch
+        self.message = message
+        self.status = 'running'
+        self.log = ''
+
+    def make(self):
+        print('====== %s =======' % self.repo)
+        os.chdir(self.full_repo_path())
+
+        print(self.full_repo_path())
+
+        steps = [
+            Step(['git', 'checkout', self.branch],
+                 'set branch', self),
+            Step(['git', 'commit', '-a', '-m', self.message],
+                 'git commit -a -m {}'.format(self.message), self),
+            Step(['git', 'push', 'origin', self.branch],
+                 'push changes', self),
+            ]
+
+        for s in steps:
+            s.run()
+        if self.status != 'failed' and self.status != 'skipped':
+            self.status = 'success'
+        return
+
+
+class PublishTask(Task):
+    def __init__(self, base, repo):
+        self.base = base
+        self.repo = repo
+        self.status = 'running'
+        self.log = ''
+
+    def make(self):
+        print('====== %s =======' % self.repo)
+        os.chdir(self.full_repo_path())
+
+        steps = [
+            Step(['make', 'publish'],
+                 'make publish',
+                 self),
+        ]
+
+        for s in steps:
+            s.run()
+        if self.status != 'failed' and self.status != 'skipped':
+            self.status = 'success'
+        return
+
+
+class RequirementsUpdateTask(Task):
+    def __init__(self, base, repo, match, replace):
+        self.base = base
+        self.repo = repo
+        self.match = match
+        self.replace = replace
+        self.status = 'running'
+        self.log = ''
+
+    def make(self):
+        print('====== %s =======' % self.repo)
+        os.chdir(self.full_repo_path())
+
+        steps = [
+            Step(["perl", "-pi", "-e", self.replace_pattern(),
+                 self.requirements_path()], "search/replace",
+                 self)
+        ]
+
+        for s in steps:
+            s.run()
+        if self.status != "failed" and self.status != "skipped":
+            self.status = "success"
+        return
+
+
+class MergeMatchingPullRequestTask(Task):
+    def __init__(self, base, repo, owner, pattern, api_token):
+        self.base = base
+        self.repo = repo
+        self.owner = owner
+        self.pattern = pattern
+        self.status = 'running'
+        self.headers = {'Authorization': 'token %s' % api_token}
+        self.log = ''
+
+    def make(self):
+        print('====== %s =======' % self.repo)
+        os.chdir(self.full_repo_path())
+
+        git_base = 'https://api.github.com/repos'
+
+        status_url = '{}/{}/{}/commits/{}/status'.format(
+            git_base, self.owner, self.repo, self.pattern)
+
+        response = requests.get(status_url, headers=self.headers)
+        if (response.status_code != 200 or
+                response.json()['state'] != 'success'):
+            self.status = 'skipped'
+            return
+
+        pullrequest_url = '{}/{}/{}/pulls'.format(
+            git_base, self.owner, self.repo)
+
+        response = requests.get(pullrequest_url, headers=self.headers)
+        if (response.status_code != 200):
+            self.status = 'skipped'
+            return
+
+        # find the matching pull request
+        steps = []
+        for pr in response.json():
+            if self.pattern == pr['head']['ref']:
+                steps.append(Step(['hub', 'merge', pr['html_url']],
+                                  'merge {}'.format(pr['html_url']), self))
+                steps.append(Step(['git', 'push', 'origin', 'master'],
+                                  'push to master', self))
+                break
+
+        if len(steps) < 1:
+            self.status = 'skipped'
+            return
+
+        for s in steps:
+            s.run()
+        if self.status != "failed" and self.status != "skipped":
+            self.status = "success"
+
+
+class TaskRunner(object):
+    failed = []
+    skipped = []
+    succeeded = []
+
+    def run(self, task):
+        task.make()
+        if task.status == 'failed':
+            self.failed.append((task.repo, task.log))
+        elif task.status == 'skipped':
+            self.skipped.append(task.repo)
+        else:
+            self.succeeded.append(task.repo)
+
+    def print_report(self):
+        print('===============================================')
+        print('failed: %d' % len(self.failed))
+        print('skipped: %d' % len(self.skipped))
+        print('succeeded: %d' % len(self.succeeded))
+        if len(self.skipped) > 0:
+            print('SKIPPED:')
+            for s in self.skipped:
+                print('\t%s' % s)
+        if len(self.failed) > 0:
+            print('FAILED:')
+            for (r, msg) in self.failed:
+                print('\t%s: %s' % (r, msg))
+        if len(self.succeeded) > 0:
+            print('SUCCEEDED:')
+            for r in self.succeeded:
+                print('\t%s' % r)
+        print('===============================================')


### PR DESCRIPTION
The original script defined a few operations that comprised a set of steps, like updating
a given dependency version in the requirements file. This takes the project in a slightly different direction by defining discrete tasks: Clone, Checkout, New Branch, Merge. This approach (hopefully) creates a more flexible tool to operate on multiple repositories for a variety of tasks. This also make the tool more dangerous, so use with caution.

Use cases here include:
* Updating a requirement in package.json
* Pinning a requirement in requirements.txt.
* Bulk merging a common dependency upgrade across repos.

@todo - update the README file with clearer instructions.
